### PR TITLE
Missions - Mission joining - Mission leaving - Display of joined missions

### DIFF
--- a/src/pages/Missions.js
+++ b/src/pages/Missions.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { getMissions } from '../redux/missions/missionsslice';
+import { getMissions, changeMissionStatus } from '../redux/missions/missionsslice';
 
 const Missions = () => {
   const dispatch = useDispatch();
@@ -8,6 +8,9 @@ const Missions = () => {
   if (missions.length === 0) {
     dispatch(getMissions());
   }
+  const handleClick = (mission) => {
+    dispatch(changeMissionStatus(mission));
+  };
   return (
     <table>
       <thead>
@@ -29,8 +32,17 @@ const Missions = () => {
             <th>
               {mission.description}
             </th>
-            <th>Status</th>
-            <th>Empty</th>
+            <th>
+              {mission.joined ? 'Active Member' : 'NOT A MEMBER'}
+            </th>
+            <th>
+              <button
+                type="button"
+                onClick={() => { handleClick(mission.mission_id); }}
+              >
+                {mission.joined ? 'Leave Mission' : 'Join Mission'}
+              </button>
+            </th>
           </tr>
         </tbody>
       ))}

--- a/src/pages/MyProfile.js
+++ b/src/pages/MyProfile.js
@@ -1,9 +1,24 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 
-const MyProfile = () => (
-  <div>
-    My Profile goes here!
-  </div>
-);
+const MyProfile = () => {
+  const missions = useSelector((state) => state.missionsreducer.missions);
+  const activemissions = missions.filter((mission) => mission.joined === true);
+  return (
+    <div>
+      <div>
+        <h2>My Missions</h2>
+        {activemissions.map((mission) => (
+          <div key={mission.mission_id}>
+            {mission.mission_name}
+          </div>
+        ))}
+      </div>
+      <div>
+        <h2>My Rockets</h2>
+      </div>
+    </div>
+  );
+};
 
 export default MyProfile;

--- a/src/redux/missions/missionsslice.js
+++ b/src/redux/missions/missionsslice.js
@@ -15,9 +15,12 @@ const getMissions = createAsyncThunk('missions/GetMissions', async () => {
       mission_id: mission.mission_id,
       mission_name: mission.mission_name,
       description: mission.description,
+      wikipedia: mission.wikipedia,
+      joined: false,
     };
     missions.push(object);
   });
+  console.log(missions);
   return missions;
 });
 
@@ -27,6 +30,15 @@ const missionsSlice = createSlice({
     loading: false,
     missions: [],
     error: '',
+  },
+  reducers: {
+    changeMissionStatus(state, action) {
+      state.missions.forEach((mission) => {
+        if (mission.mission_id === action.payload) {
+          mission.joined = !mission.joined;
+        }
+      });
+    },
   },
   extraReducers: (builder) => {
     builder.addCase(getMissions.pending, (state) => {
@@ -46,3 +58,4 @@ const missionsSlice = createSlice({
 
 export default missionsSlice.reducer;
 export { getMissions };
+export const { changeMissionStatus } = missionsSlice.actions;


### PR DESCRIPTION
### Hello, @Camilovelag !

This is my work on issues https://github.com/asdt560/rocket-mission-list/issues/10, https://github.com/asdt560/rocket-mission-list/issues/9, and https://github.com/asdt560/rocket-mission-list/issues/2. These are joining missions, leaving missions, and displaying the missions which have been joined within the MyProfile page, respectively. I worked on these in tandem due to their close interrelation. 

As for the way the code functions, The joined key/value pair, which each object in the missions array within the state possesses, is a simple boolean which is inverted by the reducer every time an action is dispatched with the id of the mission which a user wishes to join or leave.

I await your opinion on this code and any possible suggestions for improvement.

EDIT: having read the issues more closely I have changed the key in question from joined to reserved to more closely comply with what was asked. Functionality should remain the same.

